### PR TITLE
Create vibration control home experience

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -1,5 +1,4 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import { Collapsible } from '@/components/ui/collapsible';
 import { ExternalLink } from '@/components/external-link';
@@ -9,15 +8,15 @@ import { ThemedView } from '@/components/themed-view';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Fonts } from '@/constants/theme';
 
-export default function TabTwoScreen() {
+export default function ExploreScreen() {
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
+      headerBackgroundColor={{ light: '#D8F1FF', dark: '#102334' }}
       headerImage={
         <IconSymbol
-          size={310}
-          color="#808080"
-          name="chevron.left.forwardslash.chevron.right"
+          size={300}
+          color="#0284C7"
+          name="waveform.path.ecg"
           style={styles.headerImage}
         />
       }>
@@ -27,72 +26,65 @@ export default function TabTwoScreen() {
           style={{
             fontFamily: Fonts.rounded,
           }}>
-          Explore
+          Guía de vibraciones
         </ThemedText>
       </ThemedView>
-      <ThemedText>This app includes example code to help you get started.</ThemedText>
-      <Collapsible title="File-based routing">
+
+      <ThemedText style={styles.paragraph}>
+        Aprende a combinar respuestas hápticas para reforzar acciones importantes y mejorar la accesibilidad
+        de tus flujos. Aquí encontrarás recomendaciones para documentar patrones y evitar fatiga en la
+        experiencia de uso.
+      </ThemedText>
+
+      <Collapsible title="Tipos de respuesta rápida">
         <ThemedText>
-          This app has two screens:{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/explore.tsx</ThemedText>
+          Las opciones del inicio utilizan <ThemedText type="defaultSemiBold">expo-haptics</ThemedText> para
+          disparar respuestas nativas. Prueba cada combinación y toma nota de la sensación generada.
+        </ThemedText>
+        <ThemedText style={styles.bullet}>{'\u2022 '}Impactos: ligeros, medios y pesados. Úsalos para
+          confirmar acciones según su prioridad.</ThemedText>
+        <ThemedText style={styles.bullet}>{'\u2022 '}Notificaciones: combinan vibraciones con diferentes
+          intensidades y son útiles para estados como éxito, error o advertencia.</ThemedText>
+      </Collapsible>
+
+      <Collapsible title="Construye un patrón personalizado">
+        <ThemedText>
+          Ajusta la duración del pulso y de la pausa en milisegundos. Con{' '}
+          <ThemedText type="defaultSemiBold">Repeticiones</ThemedText> defines cuántas veces se ejecuta el
+          ciclo antes de detenerse.
         </ThemedText>
         <ThemedText>
-          The layout file in <ThemedText type="defaultSemiBold">app/(tabs)/_layout.tsx</ThemedText>{' '}
-          sets up the tab navigator.
+          Activa la opción <ThemedText type="defaultSemiBold">Repetir hasta detener</ThemedText> para dejarlo
+          funcionando en loop y evalúa la reacción del usuario al detener manualmente la vibración.
         </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/router/introduction">
-          <ThemedText type="link">Learn more</ThemedText>
+        <ThemedText style={styles.note}>
+          Nota: Los patrones personalizados sólo están disponibles en dispositivos Android. En iOS utiliza los
+          impactos y notificaciones rápidas.
+        </ThemedText>
+      </Collapsible>
+
+      <Collapsible title="Buenas prácticas de diseño">
+        <ThemedText style={styles.bullet}>{'\u2022 '}Mantén sesiones de prueba cortas para evitar
+          fatiga. Un patrón excesivo puede generar incomodidad.</ThemedText>
+        <ThemedText style={styles.bullet}>{'\u2022 '}Documenta tus configuraciones (pulso, pausa y
+          repeticiones) para replicarlas fácilmente en siguientes iteraciones.</ThemedText>
+        <ThemedText style={styles.bullet}>{'\u2022 '}Combina la vibración con otros canales de feedback,
+          como cambios de color o mensajes en pantalla.</ThemedText>
+      </Collapsible>
+
+      <Collapsible title="Recursos recomendados">
+        <ThemedText>
+          Revisa estas guías para profundizar en la implementación de vibraciones y patrones hápticos:
+        </ThemedText>
+        <ExternalLink href="https://docs.expo.dev/versions/latest/sdk/haptics/">
+          <ThemedText type="link">Documentación de expo-haptics</ThemedText>
         </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Android, iOS, and web support">
-        <ThemedText>
-          You can open this project on Android, iOS, and the web. To open the web version, press{' '}
-          <ThemedText type="defaultSemiBold">w</ThemedText> in the terminal running this project.
-        </ThemedText>
-      </Collapsible>
-      <Collapsible title="Images">
-        <ThemedText>
-          For static images, you can use the <ThemedText type="defaultSemiBold">@2x</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">@3x</ThemedText> suffixes to provide files for
-          different screen densities
-        </ThemedText>
-        <Image
-          source={require('@/assets/images/react-logo.png')}
-          style={{ width: 100, height: 100, alignSelf: 'center' }}
-        />
-        <ExternalLink href="https://reactnative.dev/docs/images">
-          <ThemedText type="link">Learn more</ThemedText>
+        <ExternalLink href="https://reactnative.dev/docs/vibration">
+          <ThemedText type="link">API Vibration de React Native</ThemedText>
         </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Light and dark mode components">
-        <ThemedText>
-          This template has light and dark mode support. The{' '}
-          <ThemedText type="defaultSemiBold">useColorScheme()</ThemedText> hook lets you inspect
-          what the user&apos;s current color scheme is, and so you can adjust UI colors accordingly.
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">
-          <ThemedText type="link">Learn more</ThemedText>
+        <ExternalLink href="https://material.io/design/platform-guidance/android-haptics.html">
+          <ThemedText type="link">Guía de patrones hápticos de Material Design</ThemedText>
         </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Animations">
-        <ThemedText>
-          This template includes an example of an animated component. The{' '}
-          <ThemedText type="defaultSemiBold">components/HelloWave.tsx</ThemedText> component uses
-          the powerful{' '}
-          <ThemedText type="defaultSemiBold" style={{ fontFamily: Fonts.mono }}>
-            react-native-reanimated
-          </ThemedText>{' '}
-          library to create a waving hand animation.
-        </ThemedText>
-        {Platform.select({
-          ios: (
-            <ThemedText>
-              The <ThemedText type="defaultSemiBold">components/ParallaxScrollView.tsx</ThemedText>{' '}
-              component provides a parallax effect for the header image.
-            </ThemedText>
-          ),
-        })}
       </Collapsible>
     </ParallaxScrollView>
   );
@@ -100,13 +92,28 @@ export default function TabTwoScreen() {
 
 const styles = StyleSheet.create({
   headerImage: {
-    color: '#808080',
     bottom: -90,
-    left: -35,
+    left: -45,
     position: 'absolute',
   },
   titleContainer: {
     flexDirection: 'row',
     gap: 8,
+  },
+  paragraph: {
+    marginBottom: 12,
+    lineHeight: 22,
+    fontSize: 15,
+  },
+  bullet: {
+    marginTop: 8,
+    lineHeight: 20,
+    fontSize: 14,
+  },
+  note: {
+    marginTop: 12,
+    lineHeight: 20,
+    fontSize: 14,
+    fontStyle: 'italic',
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,98 +1,423 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  TextInput,
+  View,
+  Vibration,
+} from 'react-native';
+import * as Haptics from 'expo-haptics';
 
-import { HelloWave } from '@/components/hello-wave';
-import ParallaxScrollView from '@/components/parallax-scroll-view';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
-import { Link } from 'expo-router';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+type StatusType = 'info' | 'success' | 'error';
+
+type StatusState = {
+  message: string;
+  type: StatusType;
+} | null;
+
+type QuickAction = {
+  title: string;
+  subtitle: string;
+  onPress: () => void | Promise<void>;
+  message: string;
+};
 
 export default function HomeScreen() {
-  return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }>
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <Link href="/modal">
-          <Link.Trigger>
-            <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-          </Link.Trigger>
-          <Link.Preview />
-          <Link.Menu>
-            <Link.MenuAction title="Action" icon="cube" onPress={() => alert('Action pressed')} />
-            <Link.MenuAction
-              title="Share"
-              icon="square.and.arrow.up"
-              onPress={() => alert('Share pressed')}
-            />
-            <Link.Menu title="More" icon="ellipsis">
-              <Link.MenuAction
-                title="Delete"
-                icon="trash"
-                destructive
-                onPress={() => alert('Delete pressed')}
-              />
-            </Link.Menu>
-          </Link.Menu>
-        </Link>
+  const [pulseDuration, setPulseDuration] = useState('500');
+  const [pauseDuration, setPauseDuration] = useState('300');
+  const [repetitions, setRepetitions] = useState('3');
+  const [repeatPattern, setRepeatPattern] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+  const [status, setStatus] = useState<StatusState>(null);
 
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
+  const heroBackground = useThemeColor({ light: '#E8F6FF', dark: '#0B1924' }, 'background');
+  const surfaceBackground = useThemeColor({ light: '#FFFFFF', dark: '#0A141F' }, 'background');
+  const quickCardBackground = useThemeColor({ light: '#F1F5F9', dark: '#1C2532' }, 'background');
+  const textColor = useThemeColor({}, 'text');
+  const inputBackground = useThemeColor({ light: '#FFFFFF', dark: '#081119' }, 'background');
+  const inputBorder = useThemeColor({ light: '#CBD5E1', dark: '#1F2A37' }, 'icon');
+  const placeholderColor = useThemeColor({ light: '#64748B', dark: '#7A8597' }, 'icon');
+  const primaryColor = useThemeColor({}, 'tint');
+  const infoColor = useThemeColor({ light: '#1D4ED8', dark: '#93C5FD' }, 'tint');
+  const successColor = useThemeColor({ light: '#047857', dark: '#34D399' }, 'tint');
+  const errorColor = useThemeColor({ light: '#DC2626', dark: '#FCA5A5' }, 'tint');
+
+  const quickActions: QuickAction[] = [
+    {
+      title: 'Impacto suave',
+      subtitle: 'Confirma acciones secundarias con un pulso ligero.',
+      onPress: () => void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light),
+      message: 'Se envió un impacto suave.',
+    },
+    {
+      title: 'Impacto medio',
+      subtitle: 'Útil para resaltar acciones principales.',
+      onPress: () => void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium),
+      message: 'Se envió un impacto medio.',
+    },
+    {
+      title: 'Impacto pesado',
+      subtitle: 'Ideal para alertas de alto nivel.',
+      onPress: () => void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy),
+      message: 'Se envió un impacto pesado.',
+    },
+    {
+      title: 'Notificación (éxito)',
+      subtitle: 'Feedback compuesto para notificar confirmaciones.',
+      onPress: () => void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success),
+      message: 'Notificación de éxito ejecutada.',
+    },
+  ];
+
+  const statusColors: Record<StatusType, string> = {
+    info: infoColor,
+    success: successColor,
+    error: errorColor,
+  };
+
+  useEffect(() => {
+    return () => {
+      Vibration.cancel();
+    };
+  }, []);
+
+  const sanitizeNumericValue = useCallback((value: string) => value.replace(/[^0-9]/g, ''), []);
+
+  const handleQuickPress = useCallback(
+    (action: QuickAction) => {
+      Vibration.cancel();
+      setIsRunning(false);
+      setStatus({ message: action.message, type: 'info' });
+      void action.onPress();
+    },
+    []
+  );
+
+  const handleStartPattern = useCallback(() => {
+    const vibrationMs = Number(pulseDuration);
+    const pauseMs = Number(pauseDuration);
+    const reps = Number(repetitions);
+
+    if ([vibrationMs, pauseMs, reps].some((value) => !Number.isFinite(value) || value <= 0)) {
+      setStatus({
+        message: 'Ingresa valores mayores a cero para crear el patrón.',
+        type: 'error',
+      });
+      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+      return;
+    }
+
+    const pattern: number[] = [0];
+
+    for (let index = 0; index < reps; index += 1) {
+      pattern.push(vibrationMs);
+      const shouldAddPause = index < reps - 1 || repeatPattern;
+      if (shouldAddPause) {
+        pattern.push(pauseMs);
+      }
+    }
+
+    if (pattern.length <= 1) {
+      setStatus({
+        message: 'Configura al menos un pulso para iniciar la secuencia.',
+        type: 'error',
+      });
+      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+      return;
+    }
+
+    Vibration.cancel();
+    Vibration.vibrate(pattern, repeatPattern);
+    setIsRunning(true);
+
+    const totalDuration = reps * vibrationMs + Math.max(reps - 1, 0) * pauseMs;
+    const seconds = (totalDuration / 1000).toFixed(1).replace(/\.0$/, '');
+
+    setStatus({
+      message: repeatPattern
+        ? `Patrón en ejecución continua. Cada ciclo dura aproximadamente ${seconds} s.`
+        : `Patrón iniciado por ${seconds} s aproximados.`,
+      type: 'success',
+    });
+
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  }, [pauseDuration, pulseDuration, repeatPattern, repetitions]);
+
+  const handleStopPattern = useCallback(() => {
+    Vibration.cancel();
+    setIsRunning(false);
+    setStatus({ message: 'Patrón detenido.', type: 'info' });
+    void Haptics.selectionAsync();
+  }, []);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <ThemedView style={[styles.heroCard, { backgroundColor: heroBackground }]}>
+        <ThemedText type="title">Diseña tus vibraciones</ThemedText>
+        <ThemedText style={styles.heroDescription}>
+          Experimenta con respuestas hápticas rápidas o crea un patrón personalizado para tus pruebas de
+          usabilidad.
         </ThemedText>
       </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
+
+      <ThemedView style={[styles.section, { backgroundColor: surfaceBackground }]}>
+        <ThemedText type="subtitle">Pruebas rápidas</ThemedText>
+        <ThemedText style={styles.sectionDescription}>
+          Lanza un pulso inmediato para validar el tono de tus interacciones. Cada opción utiliza la API de
+          expo-haptics.
+        </ThemedText>
+        <View style={styles.quickGrid}>
+          {quickActions.map((action) => (
+            <Pressable
+              key={action.title}
+              onPress={() => handleQuickPress(action)}
+              style={({ pressed }) => [
+                styles.quickButton,
+                {
+                  backgroundColor: quickCardBackground,
+                  borderColor: inputBorder,
+                  opacity: pressed ? 0.85 : 1,
+                },
+              ]}>
+              <ThemedText type="defaultSemiBold">{action.title}</ThemedText>
+              <ThemedText style={styles.quickSubtitle}>{action.subtitle}</ThemedText>
+            </Pressable>
+          ))}
+        </View>
+      </ThemedView>
+
+      <ThemedView style={[styles.section, { backgroundColor: surfaceBackground }]}>
+        <ThemedText type="subtitle">Patrón personalizado</ThemedText>
+        <ThemedText style={styles.sectionDescription}>
+          Define los valores en milisegundos para controlar la duración de cada pulso y las pausas entre
+          ellos. Los patrones personalizados están disponibles en Android.
+        </ThemedText>
+
+        <View style={styles.inputsRow}>
+          <View style={styles.inputGroup}>
+            <ThemedText type="defaultSemiBold">Pulso (ms)</ThemedText>
+            <TextInput
+              value={pulseDuration}
+              onChangeText={(value) => setPulseDuration(sanitizeNumericValue(value))}
+              keyboardType="number-pad"
+              inputMode="numeric"
+              maxLength={5}
+              placeholder="500"
+              placeholderTextColor={placeholderColor}
+              style={[
+                styles.textInput,
+                { backgroundColor: inputBackground, borderColor: inputBorder, color: textColor },
+              ]}
+              accessibilityLabel="Duración del pulso en milisegundos"
+              returnKeyType="done"
+            />
+          </View>
+
+          <View style={styles.inputGroup}>
+            <ThemedText type="defaultSemiBold">Pausa (ms)</ThemedText>
+            <TextInput
+              value={pauseDuration}
+              onChangeText={(value) => setPauseDuration(sanitizeNumericValue(value))}
+              keyboardType="number-pad"
+              inputMode="numeric"
+              maxLength={5}
+              placeholder="300"
+              placeholderTextColor={placeholderColor}
+              style={[
+                styles.textInput,
+                { backgroundColor: inputBackground, borderColor: inputBorder, color: textColor },
+              ]}
+              accessibilityLabel="Duración de la pausa en milisegundos"
+              returnKeyType="done"
+            />
+          </View>
+
+          <View style={styles.inputGroup}>
+            <ThemedText type="defaultSemiBold">Repeticiones</ThemedText>
+            <TextInput
+              value={repetitions}
+              onChangeText={(value) => setRepetitions(sanitizeNumericValue(value))}
+              keyboardType="number-pad"
+              inputMode="numeric"
+              maxLength={3}
+              placeholder="3"
+              placeholderTextColor={placeholderColor}
+              style={[
+                styles.textInput,
+                { backgroundColor: inputBackground, borderColor: inputBorder, color: textColor },
+              ]}
+              accessibilityLabel="Número de repeticiones"
+              returnKeyType="done"
+            />
+          </View>
+        </View>
+
+        <View style={styles.switchRow}>
+          <Switch
+            value={repeatPattern}
+            onValueChange={(value) => {
+              setRepeatPattern(value);
+              void Haptics.selectionAsync();
+            }}
+            trackColor={{ false: inputBorder, true: primaryColor }}
+            ios_backgroundColor={inputBorder}
+          />
+          <ThemedText>Repetir hasta detener</ThemedText>
+        </View>
+
+        <View style={styles.actionsRow}>
+          <Pressable
+            onPress={handleStartPattern}
+            style={({ pressed }) => [
+              styles.primaryButton,
+              { backgroundColor: primaryColor, opacity: pressed ? 0.85 : 1 },
+            ]}>
+            <ThemedText style={styles.primaryButtonText}>Iniciar patrón</ThemedText>
+          </Pressable>
+          <Pressable
+            onPress={handleStopPattern}
+            disabled={!isRunning}
+            style={({ pressed }) => [
+              styles.secondaryButton,
+              {
+                backgroundColor: quickCardBackground,
+                borderColor: inputBorder,
+                opacity: !isRunning ? 0.5 : pressed ? 0.85 : 1,
+              },
+            ]}>
+            <ThemedText style={[styles.secondaryButtonText, { color: textColor }]}>Detener</ThemedText>
+          </Pressable>
+        </View>
+
+        {status ? (
+          <View style={[styles.statusPill, { backgroundColor: quickCardBackground }]}
+            accessibilityLiveRegion="polite">
+            <ThemedText style={[styles.statusText, { color: statusColors[status.type] }]}>
+              {status.message}
+            </ThemedText>
+          </View>
+        ) : null}
+
+        <ThemedText style={styles.helperText}>
+          Consejo: mantén las repeticiones entre 1 y 10 para obtener patrones fáciles de comparar durante las
+          pruebas de experiencia de usuario.
         </ThemedText>
       </ThemedView>
-    </ParallaxScrollView>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
+  container: {
+    paddingHorizontal: 24,
+    paddingVertical: 24,
+    gap: 24,
+  },
+  heroCard: {
+    borderRadius: 24,
+    padding: 24,
+    gap: 12,
+  },
+  heroDescription: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  section: {
+    borderRadius: 24,
+    padding: 24,
+    gap: 16,
+  },
+  sectionDescription: {
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  quickGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  quickButton: {
+    borderRadius: 18,
+    paddingVertical: 18,
+    paddingHorizontal: 18,
+    flexBasis: '48%',
+    flexGrow: 1,
+    gap: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  quickSubtitle: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  inputsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 16,
+  },
+  inputGroup: {
+    flex: 1,
+    minWidth: 140,
+    gap: 8,
+  },
+  textInput: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  switchRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    gap: 12,
   },
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
+  actionsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
   },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
+  primaryButton: {
+    borderRadius: 16,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    flex: 1,
+  },
+  primaryButtonText: {
+    textAlign: 'center',
+    color: '#FFFFFF',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  secondaryButton: {
+    borderRadius: 16,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    flex: 1,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  secondaryButtonText: {
+    textAlign: 'center',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  statusPill: {
+    alignSelf: 'flex-start',
+    borderRadius: 999,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  statusText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  helperText: {
+    fontSize: 13,
+    lineHeight: 18,
   },
 });

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'waveform.path.ecg': 'vibration',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- replace the starter Home tab with a vibration-focused experience that offers quick haptic actions and a configurable pattern builder
- rewrite the Explore tab with guidance for testing vibration patterns and curated documentation links
- map the new waveform SF Symbol to the Material icon set so the updated artwork renders on every platform

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d143e38468832d9a5168d8670aad66